### PR TITLE
Reclaim gpio0 from the lcd peripheral

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ this is the first version not all the functionalities of the I2SClocklessledDriv
 ### What is to know
 * It's been tested with arduino esp32 2.0.5 core
 * The LCD driver for the esp32S3 doesn't work as the same as the lcd for the esp32. Hence the implementation is different. It is required to transform all the leds into a big buffer.
-* do not use pin 0. It's used in the code as 'ghost pin'. If I undo the esp_lcd_new_i80_bus, I can avoid this but i cannot ensure compatibility with the next core library ( that is what happen with the first version under esp-idf which was not compatible with v5 anymore)
 * You need to activate the PSRAM for it to work as the buffers are declared in PSRAM
 * Do  not hesitate to contact me 
 

--- a/src/I2SClockLessLedDriveresp32s3.h
+++ b/src/I2SClockLessLedDriveresp32s3.h
@@ -306,6 +306,11 @@ for (int i=numstrip;i<16;i++)
 io_config.on_color_trans_done = flush_ready;
                  ESP_ERROR_CHECK(esp_lcd_new_panel_io_i80(i80_bus, &io_config, &led_io_handle));
 
+    // reclaim GPIO0 back from the LCD peripheral. esp_lcd_new_i80_bus requires
+    // wr and dc to be valid gpio and we used 0, however we don't need those
+    // signals for our LED stuff so we can reclaim it here.
+    esp_rom_gpio_connect_out_signal(0, SIG_GPIO_OUT_IDX, false, true);
+
     }
  #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR reclaims gpio0 so it isn't a "ghost pin" anymore